### PR TITLE
add new warning message

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pybossa.js",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "JavaScript library to interact with a PyBossa server.",
   "main": "pybossa.js",
   "directories": {

--- a/pybossa.js
+++ b/pybossa.js
@@ -141,6 +141,9 @@
                 offset = offset || 0;
                 var def = $.Deferred();
                 var taskId = _getCurrentTaskId(_window.location.pathname);
+                if (typeof project === 'undefined' || !project) {
+                    console.log("Warning: project seems undefined. Did you run in your project pybossa.run('projectname'); with the right name?");
+                };
                 var xhr = (taskId && (previousTask === undefined)) ? _fetchTask(taskId) : _fetchNewTask(project.id, offset);
                 xhr.done(function(task) {
                     if (previousTask && task.id === previousTask.id) {


### PR DESCRIPTION
Add new warning message.
This error happens if you forget to run `pybossa.run('xyz');` in your project template or run it with wrong project name.

It looks like this on error:
![image](https://cloud.githubusercontent.com/assets/1050582/22107054/e1d4f434-de86-11e6-8676-3da52d970c2b.png)
